### PR TITLE
removes test mood_logs data from `db.sql` file

### DIFF
--- a/server/db.sql
+++ b/server/db.sql
@@ -283,16 +283,6 @@ COPY public.emojis (id, emoji, label) FROM stdin;
 3	☹️	unhappy
 \.
 
-
---
--- Data for Name: mood_logs; Type: TABLE DATA; Schema: public; Owner: steph
---
-
-COPY public.mood_logs (id, user_id, emoji_id, journal_entry, sentiment_score, created_at) FROM stdin;
-1	1	1	today was a good day! i had a lot of fun building this app!	0.8	2025-04-28 11:02:29.993013
-\.
-
-
 --
 -- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: steph
 --


### PR DESCRIPTION
### 📝 Description  
This PR is in response to the sentiments found [here](https://github.com/stmcpeters/VibeCheck/pull/41#discussion_r2064508982). It removes all `INSERT INTO mood_logs` (or equivalent) statements from `db.sql`. Mood log entries should be created dynamically through user interaction, not pre-seeded in the database.

### 🔂 Changes Made  
- Removed all hardcoded mood log data from `db.sql`.  
- Ensured the `CREATE TABLE mood_logs` definition remains untouched.

### ⚙️ Related Issue  
#4   
#54 

### 🍏 Type of Change  
- [x] Code clean up  

### 🧰 New Environment Variables or Requirements  
N/A

### 🧪 How to test  
1. Run the app and initialize the database using the updated `db.sql`.  
2. Confirm no mood logs exist on first launch.  
3. Use the app to create a new mood log.  
4. Verify the new log is saved and can be viewed as expected.


### 🚀 Deployment Notes (if applicable)  
N/A

### 📸 Screenshots (if applicable)  
N/A

### ✅ Checklist  
- [x] I have performed a self-review of my code.  
- [x] My code follows the style guidelines of this project.  
- [x] I have commented my code where necessary.  
- [x] I have tested my code locally and verified the website is working as expected.  
- [ ] (if applicable) I have added documentation in the README.  
- [ ] (if applicable) I have added tests that prove my fix is effective or that my feature works.  
- [ ] (if applicable) New and existing unit tests pass locally with my changes.


