### PR TITLE
implement pagination for mood logs and articles

### DIFF
--- a/client/src/pages/ArticlesList.jsx
+++ b/client/src/pages/ArticlesList.jsx
@@ -11,6 +11,11 @@ export default function ArticlesList({ articles, setArticles }) {
   const [currentPage, setCurrentPage] = useState(1);
   const articlesPerPage = 5;
 
+  // Reset currentPage to 1 when articles change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [articles]);
+  
   // Fetch articles from DB
   const fetchArticles = async () => {
     setLoading(true);

--- a/client/src/pages/ArticlesList.jsx
+++ b/client/src/pages/ArticlesList.jsx
@@ -8,6 +8,8 @@ import axios from 'axios'
 export default function ArticlesList({ articles, setArticles }) {
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const articlesPerPage = 5;
 
   // Fetch articles from DB
   const fetchArticles = async () => {
@@ -37,6 +39,20 @@ export default function ArticlesList({ articles, setArticles }) {
     setLoading(false);
   };
 
+  // Calculate the current articles to display
+  const indexOfLastArticle = currentPage * articlesPerPage;
+  const indexOfFirstArticle = indexOfLastArticle - articlesPerPage;
+  const currentArticles = articles.slice(indexOfFirstArticle, indexOfLastArticle);
+
+    // Calculate total pages
+  const totalPages = Math.ceil(articles.length / articlesPerPage);
+
+  const handlePageChange = (newPage) => {
+    if (newPage > 0 && newPage <= totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
+
   return (
     <>
       <NavBar />
@@ -49,7 +65,27 @@ export default function ArticlesList({ articles, setArticles }) {
           {loading ? 'Loading...' : 'Load Articles Only'}
         </button>
         {msg && <div>{msg}</div>}
-        <ArticleItem articles={articles} />
+        <ArticleItem articles={currentArticles} />
+        {/* Pagination */}
+        <div className="join">
+          <button
+            className="join-item btn"
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+          >
+            «
+          </button>
+          <span className="join-item btn btn-disabled">
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            className="join-item btn"
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+          >
+            »
+          </button>
+        </div>
       </div>
       <Footer />
     </>

--- a/client/src/pages/MoodLogsList.jsx
+++ b/client/src/pages/MoodLogsList.jsx
@@ -1,24 +1,55 @@
 // Displays paginated list of previous mood entries with search and filter options
-import React from 'react'
+import React, { useState } from 'react'
 import NavBar from '../components/NavBar'
 import Footer from '../components/Footer'
 import MoodLogItem from '../components/MoodLogItem'
 
 export default function MoodLogsList({ mood_logs }) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const logsPerPage = 5;
+
+  // Calculate the current mood logs to display
+  const indexOfLastLog = currentPage * logsPerPage;
+  const indexOfFirstLog = indexOfLastLog - logsPerPage;
+  const currentMoodLogs = mood_logs.slice(indexOfFirstLog, indexOfLastLog);
+
+  // Calculate total pages
+  const totalPages = Math.ceil(mood_logs.length / logsPerPage);
+
+  const handlePageChange = (newPage) => {
+    if (newPage > 0 && newPage <= totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
+
   return (
     <>
       <NavBar />
       <div className='place-items-center'>
         <div className='grow text-2xl'>List of Mood Logs</div>
-        <MoodLogItem mood_logs={mood_logs} />
-        {/* pagination */}
+        <MoodLogItem mood_logs={currentMoodLogs} />
+        {/* Pagination */}
         <div className="join">
-          <button className="join-item btn btn-disabled">«</button>
-          <button className="join-item btn">Page 1</button>
-          <button className="join-item btn">»</button>
+          <button
+            className="join-item btn"
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+          >
+            «
+          </button>
+          <span className="join-item btn btn-disabled">
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            className="join-item btn"
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+          >
+            »
+          </button>
         </div>
-        {/* end of pagination */}
-      </div>
+        {/* End of Pagination */}
+        </div>
       <Footer />
     </>
   )

--- a/client/src/pages/MoodLogsList.jsx
+++ b/client/src/pages/MoodLogsList.jsx
@@ -1,11 +1,16 @@
 // Displays paginated list of previous mood entries with search and filter options
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import NavBar from '../components/NavBar'
 import Footer from '../components/Footer'
 import MoodLogItem from '../components/MoodLogItem'
 
 export default function MoodLogsList({ mood_logs }) {
   const [currentPage, setCurrentPage] = useState(1);
+
+  // Reset currentPage to 1 when mood_logs changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [mood_logs]);
   const logsPerPage = 5;
 
   // Calculate the current mood logs to display


### PR DESCRIPTION
### 📝 Description  
This PR adds pagination functionality for mood logs and articles on the frontend. The feature allows users to view a 5 entries per page and navigate between pages.

### 🔂 Changes Made  
- Added pagination to the frontend for mood logs and articles  
- Updated frontend to display paginated mood logs and articles  
- Implemented page navigation controls (next, previous)  
- Added query parameters to manage page number and page size  
- Updated UI to handle loading states and empty pages

### ⚙️ Related Issue  
#19  
(Parent Issue: #10)

### 🍏 Type of Change  
- [x] New feature  

### 🧰 New Environment Variables or Requirements  
None

### 🧪 How to test  
1. Start the backend and frontend servers.  
2. Navigate to the mood logs and articles pages.  
3. Verify only 5 entries appear per page.  
4. Use navigation buttons to move between pages.  
5. Confirm page data updates without reloading the entire app.  
6. Test edge cases like no data, last page, and invalid page numbers.

### 🚀 Deployment Notes (if applicable)  
N/A

### 📸 Screenshots (if applicable)  

https://github.com/user-attachments/assets/fbb5be43-c75e-4e96-9b40-b69c9340e381



### ✅ Checklist  
- [x] I have performed a self-review of my code.  
- [x] My code follows the style guidelines of this project.  
- [x] I have commented my code where necessary.  
- [x] I have tested my code locally and verified the website is working as expected.  
- [ ] (if applicable) I have added documentation in the README.  
- [] (if applicable) I have added tests that prove my fix is effective or that my feature works.  
- [] (if applicable) New and existing unit tests pass locally with my changes.
